### PR TITLE
♻️ refactor can communication name

### DIFF
--- a/robot_embedded_ver1/inc/can_communication.h
+++ b/robot_embedded_ver1/inc/can_communication.h
@@ -1,12 +1,12 @@
 /**
- * @file m2006_can_communication.h
+ * @file can_communication.h
  * @author RinYoshida (tororo1219@gmail.com)
  * @brief m2006とubuntuがcan通信を行うためのヘッダファイル
  * @date 2024-07-01
  */
 
-#ifndef M2006_CAN_COMMUNICATION_H
-#define M2006_CAN_COMMUNICATION_H
+#ifndef CAN_COMMUNICATION_H
+#define CAN_COMMUNICATION_H
 
 #include <iostream>
 #include <cstdint>
@@ -18,10 +18,10 @@
 #include <linux/can.h>
 #include <linux/can/raw.h>
 
-class M2006CanCommunication{
+class CanCommunication{
 public:
-    M2006CanCommunication(const string can_interface_name);
-    ~M2006CanCommunication();
+    CanCommunication(const string can_interface_name);
+    ~CanCommunication();
 
     /**
      * @brief CAN通信を行うための関数
@@ -37,3 +37,5 @@ public:
     struct can_frame frame_;
     struct ifreq ifr_;
 };
+
+#endif // CAN_COMMUNICATION_H

--- a/robot_embedded_ver1/src/can_communication.cc
+++ b/robot_embedded_ver1/src/can_communication.cc
@@ -1,13 +1,13 @@
 /**
- * @file m2006_can_communication.cc
+ * @file can_communication.cc
  * @author RinYoshida (tororo1219@gmail.com)
  * @brief m2006とubuntuがcan通信を行うためのクラス
  * @date 2024-07-01
  */
 
-#include "m2006_can_communication.h"
+#include "can_communication.h"
 
-M2006CanCommunication::M2006CanCommunication(const string can_interface_name) : can_interface_name_(can_interface_name){
+CanCommunication::CanCommunication(const string can_interface_name) : can_interface_name_(can_interface_name){
     socket_can_ = socket(PF_CAN, SOCK_RAW, CAN_RAW);
     strcpy(ifr_.ifr_name, can_interface_name_.c_str());
     ioctl(socket_can_, SIOCGIFINDEX, &ifr);
@@ -17,11 +17,11 @@ M2006CanCommunication::M2006CanCommunication(const string can_interface_name) : 
     bind(socket_can_, (struct sockaddr *)&addr_, sizeof(addr_));
 }
 
-M2006CanCommunication::~M2006CanCommunication(){
+CanCommunication::~CanCommunication(){
     close(socket_can_);
 }
 
-void M2006CanCommunication::socketCanSend(const uint16_t can_id, const uint8_t *can_data, const uint8_t size){
+void CanCommunication::socketCanSend(const uint16_t can_id, const uint8_t *can_data, const uint8_t size){
     frame_.can_id = can_id;
     frame_.can_dlc = size;
     for (int i = 0; i < size; i++){


### PR DESCRIPTION
- ubuntuとペリフェラルがcan通信をするための関数なのでm2006がつくのはおかしい。
- m2006のrename