### PR TITLE
🐛 fix can id of can communication

### DIFF
--- a/robot_embedded_ver1/inc/can_communication.h
+++ b/robot_embedded_ver1/inc/can_communication.h
@@ -32,7 +32,7 @@ public:
      * @retval 正: 正常終了　送信バイト数
      * @retval 負: 送信失敗
      */
-    int8_t socketCanSend(const uint16_t can_id, const uint8_t *can_data, const uint8_t size);
+    int8_t socketCanSend(const uint32_t can_id, const uint8_t *can_data, const uint8_t size);
 
     /**
      * @brief CAN通信で受信を行うための関数
@@ -44,7 +44,7 @@ public:
      * @retval 正: 正常終了　受信バイト数
      * @retval 負: 受信失敗
      */
-    int8_t socketCanReceive(uint16_t &can_id, uint8_t *can_data, uint8_t &size);
+    int8_t socketCanReceive(uint32_t &can_id, uint8_t *can_data, uint8_t &size);
 
 private:
     std::string can_interface_name_; // CANインターフェース名

--- a/robot_embedded_ver1/src/can_communication.cc
+++ b/robot_embedded_ver1/src/can_communication.cc
@@ -21,7 +21,7 @@ CanCommunication::~CanCommunication(){
     close(socket_can_);
 }
 
-int8_t CanCommunication::socketCanSend(const uint16_t can_id, const uint8_t *can_data, const uint8_t size){
+int8_t CanCommunication::socketCanSend(const uint32_t can_id, const uint8_t *can_data, const uint8_t size){
     frame_.can_id = can_id;
     frame_.can_dlc = size;
     for (int i = 0; i < size; i++){
@@ -31,7 +31,7 @@ int8_t CanCommunication::socketCanSend(const uint16_t can_id, const uint8_t *can
     return write_err_check;
 }
 
-int8_t CanCommunication::socketCanReceive(uint16_t &can_id, uint8_t *can_data, uint8_t &size){
+int8_t CanCommunication::socketCanReceive(uint32_t &can_id, uint8_t *can_data, uint8_t &size){
     int8_t read_err_check = read(socket_can_, &frame_, sizeof(struct can_frame));
     can_id = frame_.can_id;
     size = frame_.can_dlc;

--- a/robot_embedded_ver1/src/main.cc
+++ b/robot_embedded_ver1/src/main.cc
@@ -26,7 +26,7 @@ void maintask(){
     // 一旦buildcheck用に書いている。
     //uint16_t can_id = 200;
     uint8_t data[8] = {0};
-    uint16_t can_id;
+    uint32_t can_id;
     //std::array<uint8_t, 8> data;
     uint8_t size;
     int err = 0;


### PR DESCRIPTION
- can-idの型をuint16からuint32に変更